### PR TITLE
Simplified app config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,1 +1,31 @@
 
+import os
+
+class Config(object):
+    DEBUG = False
+    CSRF_ENABLED = True
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+
+class TestingConfig(Config):
+    TESTING = True
+    DEBUG = True
+
+class StagingConfig(Config):
+    DEBUG = True
+
+class ProductionConfig(Config):
+    DEBUG = False
+    TESTING = False
+
+app_config = {
+    'development': DevelopmentConfig,
+    'testing': TestingConfig,
+    'staging': StagingConfig,
+    'production': ProductionConfig,
+}
+
+def config_from_app_settings(app_settings):
+    return app_config[app_settings]

--- a/main.py
+++ b/main.py
@@ -4,22 +4,19 @@ from flask_api import FlaskAPI
 from flask_sqlalchemy import SQLAlchemy
 from flask import request, jsonify, abort, Flask
 from flask_cors import CORS
-from instance.config import app_config
+from config import config_from_app_settings
 import pprint
 import json
 
 db = SQLAlchemy()
 
-def create_app(config_name):
+def create_app(app_settings):
 
     from models import Task
     from models import List
 
-    app = Flask(__name__, instance_relative_config=True)
-
-    config_name = os.getenv('APP_SETTINGS')
-    app.config.from_object(app_config[config_name])
-    app.config.from_pyfile('config.py')
+    app = Flask(__name__)
+    app.config.from_object(config_from_app_settings(app_settings))
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.url_map.strict_slashes = False
 
@@ -171,8 +168,8 @@ def create_app(config_name):
 
     return app
 
-config_name = os.getenv('APP_SETTINGS')
-app = create_app(config_name)
+app_settings = os.getenv('APP_SETTINGS')
+app = create_app(app_settings)
 
 if __name__ == "__main__":
     # Only for debugging while developing

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,8 @@
 import os
-from flask_script import Manager # class for handling a set of commands
+from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand
 from main import db, app
 
-#app = create_app(config_name=os.getenv('APP_SETTINGS'))
 migrate = Migrate(app, db)
 manager = Manager(app)
 


### PR DESCRIPTION
The configuration scheme was inherited from the tutorial used to initially create the api.  From what I can tell from a few Google searches, the scheme was fairly idiomatic, but it isn't necessary for this app.

Switched instance config to main config and everything works the same and it's simpler :)